### PR TITLE
22 issue loading functions with a variable number of arguments

### DIFF
--- a/libs/loaders/include/loaders/loader.hpp
+++ b/libs/loaders/include/loaders/loader.hpp
@@ -4,6 +4,8 @@
 #include "model/cfg.hpp"
 #include "model/controller.hpp"
 #include "support/exceptions.hpp"
+#include "support/localisation.hpp"
+
 
 #include <memory>
 #include <string>
@@ -16,7 +18,14 @@ namespace MiniMC {
 
     class LoadError : public MiniMC::Support::ConfigurationException {
     public:
-      LoadError() : ConfigurationException("Failed to load program") {}
+      LoadError(const std::string& mess = "Failed to load program" ) : ConfigurationException(mess) {}
+    };
+
+    class VariadicFunctionsNotSupported : public LoadError {
+    public:
+      VariadicFunctionsNotSupported(const std::string& name) : LoadError(
+									 MiniMC::Support::Localiser("Function '%1%' is varidic. This is not supported by MiniMC").format (name)) 
+      {}
     };
 
     struct LoadResult {

--- a/libs/loaders/src/llvm/loader.cpp
+++ b/libs/loaders/src/llvm/loader.cpp
@@ -86,7 +86,9 @@ namespace MiniMC {
       return program.addFunction(name, {},
                                  program.getTypeFactory().makeVoidType(),
                                  std::move(vstack),
-                                 std::move(cfg));
+                                 std::move(cfg),
+				 false
+				 );
     }
     
 
@@ -155,9 +157,6 @@ namespace MiniMC {
 
       void  instantiateFunctions (GLoadContext& lcontext, MiniMC::Model::Program_ptr& prgm, llvm::Module& module) {
 	for (auto& F : module) {
-	  if (F.isVarArg ()) {
-	    throw VariadicFunctionsNotSupported (F.getName().str());
-	  }
 	  auto source_loc = std::make_shared<MiniMC::Model::SourceInfo>();
 	  std::string fname = F.getName().str();
 	  MiniMC::Model::CFA cfg;
@@ -232,7 +231,7 @@ namespace MiniMC {
 		
 		edgebuilder.addInstr<MiniMC::Model::InstructionCode::NonDet> ({.res = retVar, .min = min,.max=max});
 		edgebuilder.addInstr<MiniMC::Model::InstructionCode::Ret> ({retVar});
-			
+		
 	      }
 	      
 	      else {
@@ -241,7 +240,7 @@ namespace MiniMC {
 
 	    }
 	    
-	    prgm->addFunction(F.getName().str(), params, returnTy, std::move(variablestack), std::move(cfg));
+	    prgm->addFunction(F.getName().str(), params, returnTy, std::move(variablestack), std::move(cfg),F.isVarArg ());
 	  }
 
 	  else  {
@@ -361,7 +360,7 @@ namespace MiniMC {
 		
 	      }
 	    }
-	    prgm->addFunction(F.getName().str(), params, returnTy, std::move(variablestack), std::move(cfg));
+	    prgm->addFunction(F.getName().str(), params, returnTy, std::move(variablestack), std::move(cfg),F.isVarArg ());
 	  }
 	}
       }

--- a/libs/loaders/src/llvm/loader.cpp
+++ b/libs/loaders/src/llvm/loader.cpp
@@ -155,6 +155,9 @@ namespace MiniMC {
 
       void  instantiateFunctions (GLoadContext& lcontext, MiniMC::Model::Program_ptr& prgm, llvm::Module& module) {
 	for (auto& F : module) {
+	  if (F.isVarArg ()) {
+	    throw VariadicFunctionsNotSupported (F.getName().str());
+	  }
 	  auto source_loc = std::make_shared<MiniMC::Model::SourceInfo>();
 	  std::string fname = F.getName().str();
 	  MiniMC::Model::CFA cfg;

--- a/libs/loaders/src/mmc/parser.cpp
+++ b/libs/loaders/src/mmc/parser.cpp
@@ -132,7 +132,7 @@ void Parser::function() {
     auto ret = returns();
     auto cfg = cfa(name, registerDescr.get());
     prgm->addFunction(name.getFullName(), params, ret,
-                      std::move(registerDescr), std::move(cfg));
+                      std::move(registerDescr), std::move(cfg),false);
     return;
   }
   throw MMCParserException(lexer->getLine(), lexer->getPos(), lexer->getValue(),

--- a/libs/model/include/model/cfg.hpp
+++ b/libs/model/include/model/cfg.hpp
@@ -123,13 +123,15 @@ namespace MiniMC {
                const Type_ptr rtype,
                RegisterDescr_uptr&& registerdescr,
 	       CFA&& cfa,
-               Program& prgm) : name(name),
+               Program& prgm,
+	       bool varargs) : name(name),
 				parameters(params),
 				registerdescr(std::move(registerdescr)),
 				cfa(std::move(cfa)),
 				id(id),
 				prgm(prgm),
-				retType(rtype)
+			       retType(rtype),
+			       varargs(varargs)
                                           
       {
       }
@@ -143,6 +145,7 @@ namespace MiniMC {
       
       auto& getID() const { return id; }
       auto& getReturnType() const { return retType; }
+      auto& isVarArgs () const {return varargs;}
       Program& getPrgm() const { return prgm; }
 
     private:
@@ -153,6 +156,7 @@ namespace MiniMC {
       MiniMC::func_t id;
       Program& prgm;
       Type_ptr retType;
+      bool varargs;
     };
     
     class Program  {
@@ -167,8 +171,10 @@ namespace MiniMC {
 			       const std::vector<Register_ptr>& params,
 			       const Type_ptr retType,
 			       RegisterDescr_uptr&& registerdescr,
-			       CFA&& cfg) {
-        functions.push_back(std::make_shared<Function>(functions.size(), MiniMC::Model::Symbol{name}, params, retType, std::move(registerdescr), std::move(cfg), *this));
+			       CFA&& cfg,
+			       bool varargs
+			       ) {
+        functions.push_back(std::make_shared<Function>(functions.size(), MiniMC::Model::Symbol{name}, params, retType, std::move(registerdescr), std::move(cfg), *this,varargs));
         function_map.insert(std::make_pair(name, functions.back()));
         return functions.back();
       }

--- a/libs/model/include/model/cfg.hpp
+++ b/libs/model/include/model/cfg.hpp
@@ -125,11 +125,11 @@ namespace MiniMC {
 	       CFA&& cfa,
                Program& prgm,
 	       bool varargs) : name(name),
-				parameters(params),
-				registerdescr(std::move(registerdescr)),
-				cfa(std::move(cfa)),
-				id(id),
-				prgm(prgm),
+			       parameters(params),
+			       registerdescr(std::move(registerdescr)),
+			       cfa(std::move(cfa)),
+			       id(id),
+			       prgm(prgm),
 			       retType(rtype),
 			       varargs(varargs)
                                           

--- a/libs/model/src/program.cpp
+++ b/libs/model/src/program.cpp
@@ -81,7 +81,8 @@ namespace MiniMC {
 				    parameters,
 				    retType,
 				    std::move(varstack),
-				    std::move(cfa));
+				    std::move(cfa),
+				    function->isVarArgs ());
       }
 
       

--- a/libs/vm/include/vm/engine_implementation.hpp
+++ b/libs/vm/include/vm/engine_implementation.hpp
@@ -423,6 +423,9 @@ namespace MiniMC {
 						   }}
 						 ,*content.function
 						 );
+	  if (func->isVarArgs()) {
+	    throw MiniMC::Support::Exception("Vararg functions are not supported");						   
+	  }
 	  
 	  auto& vstack = func->getRegisterStackDescr();
 	  

--- a/tests/programs/dummy/hh.ll
+++ b/tests/programs/dummy/hh.ll
@@ -19,11 +19,11 @@ declare void @assert(i8 signext) #1
 ; Function Attrs: noinline nounwind optnone sspstrong uwtable
 define dso_local void @main() #0 {
   %1 = alloca i8, align 1
-  %2 = call signext i8 (...) @k()
+  %2 = call signext i8 () @k()
   store i8 %2, i8* %1, align 1
   %3 = load i8, i8* %1, align 1
   call void @check(i8 signext %3)
   ret void
 }
 
-declare signext i8 @k(...) #1
+declare signext i8 @k() #1


### PR DESCRIPTION
- clang-format file
- Format check
- Deleted format workflow
- Removed the nuisance of having SMT setup being a global setting
- Formatting
- formatting and some clean up (deleting unused parameters
- Gradual move towards a more elegant interface for creating instructions
- - Removed all the builder classes (calling instead the instruction creator directly) - Next step is to remove the Helpers
- missing file
- - Switched away from helper constructions
- - Squashed some warnings,
- - Added support for InsertValue/ExtractValue in Concrete. -
- Made heaplayout structure -- allowing "pre-allocating" memory and constructing "pre-instantiation" pointer. This has the benefit of completely removing the global register from the system (since they are just constants). It also removes the need for the ugly NonCompileConstants (i.e. those that depended on the allocating of globals)
- Deleted the debug output of the modified LLVM code
- Quashed warning
- Removed dependence on internal structure of InstructionStream
- Making "semantic" hooks out from instructioncode to the actual instructions. This moves the semantics to some extend away from the concrete CPA...allowing to reuse them in the symbolic CPA (when things are concrete)
- ff
- Quashed warnings
- Work on transferring interpretation to decidated  VM rather than implementing it constantly for all CPAs
- VM added... still integrated though
- fdh
- New VM
- Made all test cases pass
- Moving operations into external objects
- - Aggregate for new pathformula
- - Missing files - Dedicated TypeID for I8,I16,I32,I64
- More missing files
- 
- - CallStack for pathformula - Disable the "delay" feature of simulation manager
- Added LLVM to dependency sub-folder Disabled CI for now
- CI
- Disable CI
- Missing
- Enable CI again
- Hackish way to get cmake to link static libraries to shared
- Fixing the python binding
- Copy of programs
- Fixing the python binding
- missing file
- fsdfhk
- major modifications to running algorithms....everything is consolidated in the binary-plugins rather than "Algorithms classes"
- major modifications to running algorithms....everything is consolidated in the binary-plugins rather than "Algorithms classes"
- major modifications to running algorithms....everything is consolidated in the binary-plugins rather than "Algorithms classes"
- major modifications to running algorithms....everything is consolidated in the binary-plugins rather than "Algorithms classes"
- Cleanup (deleted unneeded files
- Work in progress
- Encapculating reachability in own object
- Missing file
- Missing file
- Guard against including pybind11 unless actually needing it
- Started separating instantiation of analysis state from Program.
- Fairly big changes to message setup
- Clearer ownership of VariableStacks.
- 
- Moving away from shared_ptr for CFA
- Gives ownership of CFAs to the functions (no more shared_ptr)
- Renaming of functions and class (CFA-CFG, VariableStackDesc -> RegisterDescr)
- Visitor pattern for values
- removed gsl
- - Preparing separate storage mechanisms - Streamlining the hashing a bit (as a result of debugging)
- Moved stack allocations out from heap allocations
- memory added to pathformula
- - Slight cleanup - Graceful fail
- Template similar things between pathformula and concrete CPAS
- - Put most of the logic of setting up function parameters into the VM - New HashCombiner (uses the xxhash) rather than the old hash_combiner function
- Deleted unused file
- deleted unused cmake_finds
- 
- - Moved the create entry point logic into loaders, - LLVM loader now sets up its own stack
- Removed - Alloca - ExtendObj - Free
- Make sure values are always given a type when constructed by the ConstantFactory
- Proper output for Aggregates in new MiniMC model format
- Moved reference of registerdescr onto the LocationInfo. This way we have easy access to active registers in a given context.....
- Started making a new QueryExprions setup for CPAs
- Split states into datapart and cfa part
- Started adding model generation for pathformula (still some way to go)
- Evaluation of values from PathFormulaVM
- Compile fixes for gcc12
- Deleted hard to maintain code
- reimplemented expand nodetdet
- - Making default values when initially creating register - Give warning when asking for NonDet values in Concrete analysis
- Trying to tidy up llvm loader
- Typecheking for InsertValue and ExtractValue
- - Sqaushed a few warnings - removed unused code -
- Upgraded to LLVM 14
- - Removed ugle getSize checks on types
- THrow Error when failing to load program
- h
- Proper readout of pointers from CVC4
- - removed unused cmd-line options   - should be re-added somehow though
- missing file
- Moved smtlib out of git submodule
- Proper value genration for Booleans
- - Started preparation for different pointer rep (64 and 32) - Still some problems
- - Compile-time switch between 32bit pointers and 64bit pointers. - In future it should be a runtime switch
- Removed base64
- Templated the representatins
- Operations on Pointer32
- Most setup for 32 pointers working..although there is an error making the variant valueles
- Fixed error where pointers were casted "wrongly
- Disabled CI
- Removed gsl
- CI/CD
- CI/CD fix - hopefully
- Update build.yml
- Added .gitignore
- First PoC of the Interpreter
- Intitial terminal gui added
- Printing of Variables
- Removed guihelper
- Added functionality for look ahead
- Added boolcasts and asservialotelocation to the miniinterpreter
- Moved the interpreter into bin, and added it as a command
- include cvc4 dev in workflow
- Better print
- CANT COMPILE: first attempt to introduce task in the interpreter
- test?
- Outline for the TaskFactory design
- Working CLI
- Added Bookmark functionality
- Interpreter skips noinstructionedges
- First iteration of "static" commands
- Added option of path - without functionality tho
- POC of path as argument - intp.path
- Formatting
- overall structure for the parser/lexer
- First working POC
- implemented statemap
- Edges can now be printed and a step needs an egde index
- changes to cmakelist
- Folder structure for minimc-parser
- Nothing works
- Typo in tokens
- New structure in parrser
- Removed double whitespaces
- Removed double whitespaces
- The overall structure for the parser and lexer done
- First working POC of minimc Parser
- Parser exception added and ini files updated
- Closes #7
- Squashed warnings
- Added MMC test aswell as some cases
- Added Tokens as x-macroes
- Making it easier to make fully qualified names
- Change the operations so it depedent on the ones in instruction.hpp
- - Rename - A few tests for new symbols structure
- - Changed the symbol representation to be a list of strings
- - Major rework of repository... - Libraries now have their cmake project and evertyhing related (e.g. source files, include files, tests ) to it should be confined in that project
- - (better) Packaging  into zip files - deleted unused headers
- - moved smt into own sub-project
- - Pacaking (into zip) - Updated build to package as well
- added support for map of twosigned symbols such as "##" or "->"
- Added Minor changes to the syntax and added "Aggr" type
- MiniMC parser updated such it handle Symbols instead of string names
- - Program copier actually copies entry points, - MiniMC throws error when tasks are added from cmdline - Allow running MiniMC without tasks
- Support for comments
- The parser now handles hex/digits up to a usigned long instead of int
- Fixed prefixes in MiniMC Parser
- Annotation for AssertViolated
- X-macroes is now a part of the parser for better or worse
- Addresses #13 - Changed loader selection to use the name of loaders rather than indcices into the Loader-registrar. -
- - Throw Exception when trying to store Booleans and Aggregates - Copy intialisers in program copying --- deleted unneeded assert
- Adding storing of Aggregates to concrete memory model
- Moved entry points into only being part of LLVM loader.
- Removed last remnants of old entry-point creation code
- Reenabling inlining and unrolling of loops
- Deleted old Guard stuff
- Partial solution to #20. - The LLVM Loader now create MiniMC functions for all declared functions in the LLVM module, - Functions with no definition return an Undef Value,
- Dividing huge function into sub-functions
- Attempts to fix compilation on arch linux with LLVM-15
- - Concrete undef values now calls  unbound --- it does not solve the failing the test-case. It is however more consistent :-)
- - LLVM loader now expands the undef return value rather than return undef values
- This is not a fix for #22, but it stops MiniMC of giving unfortunate error messages. Instead of the "Inconssitent parameters for ..." MiniMC reports early that Variadic functions are not supported.
- Model now allows var_arg functions. They are not type-checked parameter-wise, but a warning is given that parameter compatibility is not checked.
- - Throw error when engine encounter varargs function - Updated test program to not use varargs
